### PR TITLE
feat: refresh light mode styling

### DIFF
--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -10,37 +10,37 @@ export const Footer = () => {
 
   return (
     <footer
-      className="border-t border-white/20 bg-white/50 backdrop-blur dark:border-slate-700/40 dark:bg-slate-900/60"
+      className="border-t border-border-light bg-[#f1f5f9] text-[#334155] transition-colors duration-300 ease-out dark:border-slate-700 dark:bg-surface-dark dark:text-slate-300"
       dir={direction}
     >
-      <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-6 py-12 text-slate-600 dark:text-slate-300">
-        <div className="flex flex-col gap-4 text-sm font-semibold uppercase tracking-wide text-slate-500 sm:flex-row sm:items-center sm:justify-between">
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-6 py-12">
+        <div className="flex flex-col gap-4 text-sm font-semibold uppercase tracking-wide text-muted sm:flex-row sm:items-center sm:justify-between">
           <div className={`flex flex-wrap gap-4 ${isRTL ? "sm:flex-row-reverse" : ""}`}>
-            <a href="/#hero" onClick={createClickHandler("#hero")} className="hover:text-cyan-500">
+            <a href="/#hero" onClick={createClickHandler("#hero")} className="hover:text-accent">
               {links.home}
             </a>
-            <a href="/#courses" onClick={createClickHandler("#courses")} className="hover:text-cyan-500">
+            <a href="/#courses" onClick={createClickHandler("#courses")} className="hover:text-accent">
               {links.courses}
             </a>
-            <RouterLink to="/policy" className="hover:text-cyan-500">
+            <RouterLink to="/policy" className="hover:text-accent">
               {links.policy}
             </RouterLink>
-            <a href="/#contact" onClick={createClickHandler("#contact")} className="hover:text-cyan-500">
+            <a href="/#contact" onClick={createClickHandler("#contact")} className="hover:text-accent">
               {links.contact}
             </a>
           </div>
-          <div className={`flex flex-wrap gap-3 text-xs normal-case text-slate-500 dark:text-slate-400 ${isRTL ? "sm:flex-row-reverse" : ""}`}>
+          <div className={`flex flex-wrap gap-3 text-xs normal-case text-muted dark:text-slate-400 ${isRTL ? "sm:flex-row-reverse" : ""}`}>
             {social.map((item) => (
-              <a key={item.href} href={item.href} className="hover:text-cyan-500" target="_blank" rel="noreferrer">
+              <a key={item.href} href={item.href} className="hover:text-accent" target="_blank" rel="noreferrer">
                 {item.label}
               </a>
             ))}
           </div>
         </div>
-        <p className="text-sm text-slate-500 dark:text-slate-400 text-start [dir='rtl']:text-end">
+        <p className="text-sm text-muted dark:text-slate-400 text-start [dir='rtl']:text-end">
           {translate("footer.credit")}
         </p>
-        <p className="text-xs text-slate-400 dark:text-slate-500 text-start [dir='rtl']:text-end">
+        <p className="text-xs text-muted dark:text-slate-500 text-start [dir='rtl']:text-end">
           {translate("footer.copyright")}
         </p>
       </div>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -33,36 +33,36 @@ export const Header = () => {
     <header className="fixed inset-x-0 top-0 z-40 flex flex-col items-center">
       <div className="h-1 w-full bg-transparent">
         <motion.div
-          className="h-1 bg-gradient-to-r from-cyan-400 via-sky-500 to-indigo-500"
+          className="h-1 bg-gradient-to-r from-accent via-sky-400 to-accentSecondary"
           style={{ scaleX: progress, transformOrigin: isRTL ? "right" : "left" }}
         />
       </div>
       <nav className="mt-4 w-full px-4">
         <div
-          className="mx-auto flex max-w-6xl items-center justify-between gap-4 rounded-full border border-white/20 bg-white/70 px-6 py-3 shadow-lg shadow-slate-900/10 backdrop-blur-xl dark:border-slate-700/80 dark:bg-slate-900/80"
+          className="mx-auto flex max-w-6xl items-center justify-between gap-4 rounded-full border border-border-light/70 bg-surface-light/80 px-6 py-3 shadow-md shadow-slate-900/5 backdrop-blur-xl dark:border-border-dark/70 dark:bg-surface-dark/80"
           dir={direction}
         >
           <a href="/#hero" onClick={createClickHandler("#hero")} className="flex items-center gap-3 text-start">
-            <span className="text-lg font-semibold text-slate-900 dark:text-white">{translate("brand")}</span>
+            <span className="text-lg font-semibold text-gray-900 dark:text-slate-100">{translate("brand")}</span>
           </a>
-          <div className="hidden items-center gap-6 text-sm font-semibold text-slate-500 lg:flex" dir={direction}>
+          <div className="hidden items-center gap-6 text-sm font-semibold text-muted lg:flex" dir={direction}>
             {navItems.map((item) => (
               <a key={item.id} href={`/${item.href}`} onClick={createClickHandler(item.href)} className="relative">
-                <span className="transition hover:text-cyan-500">{item.label}</span>
+                <span className="transition hover:text-accent">{item.label}</span>
                 {activeId === item.id ? (
                   <motion.span
                     layoutId="nav-active"
-                    className="absolute -bottom-2 start-0 h-[3px] w-full rounded-full bg-cyan-400"
+                    className="absolute -bottom-2 start-0 h-[3px] w-full rounded-full bg-accent"
                   />
                 ) : null}
               </a>
             ))}
-            <RouterLink to="/policy" className="relative text-slate-500 transition hover:text-cyan-500">
+            <RouterLink to="/policy" className="relative text-muted transition hover:text-accent">
               {translate("footer.links.policy")}
               {isPolicy ? (
                 <motion.span
                   layoutId="nav-active"
-                  className="absolute -bottom-2 start-0 h-[3px] w-full rounded-full bg-cyan-400"
+                  className="absolute -bottom-2 start-0 h-[3px] w-full rounded-full bg-accent"
                 />
               ) : null}
             </RouterLink>
@@ -73,7 +73,7 @@ export const Header = () => {
             <NavDrawer navItems={navItems} policyLabel={translate("footer.links.policy")} />
           </div>
           {isPolicy ? (
-            <RouterLink to="/" className="text-sm font-semibold text-cyan-400 lg:hidden">
+            <RouterLink to="/" className="text-sm font-semibold text-accent lg:hidden">
               {isRTL ? "→" : "←"} {translate("nav.home")}
             </RouterLink>
           ) : null}

--- a/src/components/layout/LangSwitcher.tsx
+++ b/src/components/layout/LangSwitcher.tsx
@@ -6,7 +6,7 @@ export const LangSwitcher = () => {
 
   return (
     <div className="relative">
-      <div className="flex items-center gap-2 rounded-full border border-slate-200/60 bg-white/80 px-3 py-1.5 text-sm font-semibold uppercase text-slate-600 shadow-sm backdrop-blur dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200">
+      <div className="flex items-center gap-2 rounded-full border border-border-light bg-surface-light/80 px-3 py-1.5 text-sm font-semibold uppercase text-muted shadow-sm backdrop-blur dark:border-border-dark dark:bg-surface-dark/80 dark:text-text-dark">
         {languages.map((option) => (
           <button
             type="button"
@@ -18,7 +18,7 @@ export const LangSwitcher = () => {
             {language === option.code ? (
               <motion.span
                 layoutId="language-pill"
-                className="absolute inset-0 rounded-full bg-cyan-500/20"
+                className="absolute inset-0 rounded-full bg-accent/15"
                 transition={{ type: "spring", stiffness: 400, damping: 30 }}
               />
             ) : null}

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -38,9 +38,10 @@ export const Layout = () => {
 
   return (
     <div
-      className={`min-h-screen bg-gradient-to-br from-cyan-400/10 via-transparent to-indigo-500/10 pb-24 ${fontClass}`}
+      className={`min-h-screen bg-[color:var(--px-bg)] pb-24 transition-colors duration-300 ease-out ${fontClass}`}
       dir={direction}
     >
+      <div className="pointer-events-none fixed inset-0 -z-10 bg-gradient-to-br from-white via-[#f1f5f9] to-[#e2e8f0] opacity-90 dark:from-[#0f172a] dark:via-[#1e293b] dark:to-[#1e293b]" />
       <Header />
       <AnimatePresence mode="wait">
         <motion.main key={path} variants={pageVariants} initial="initial" animate="animate" exit="exit">

--- a/src/components/layout/NavDrawer.tsx
+++ b/src/components/layout/NavDrawer.tsx
@@ -19,7 +19,7 @@ export const NavDrawer = ({ navItems, policyLabel }: NavDrawerProps) => {
       <button
         type="button"
         onClick={() => setOpen((prev) => !prev)}
-        className="flex h-11 w-11 items-center justify-center rounded-full border border-slate-200/70 bg-white/80 text-slate-600 shadow-sm backdrop-blur transition hover:text-cyan-500 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200"
+        className="flex h-11 w-11 items-center justify-center rounded-full border border-border-light bg-surface-light/80 text-muted shadow-sm backdrop-blur transition hover:text-accent dark:border-border-dark dark:bg-surface-dark/80 dark:text-text-dark"
         aria-expanded={open}
         aria-label="Toggle navigation"
       >
@@ -32,7 +32,7 @@ export const NavDrawer = ({ navItems, policyLabel }: NavDrawerProps) => {
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: -10 }}
             transition={{ duration: 0.25, ease: "easeOut" }}
-            className={`absolute ${isRTL ? "left-4" : "right-4"} top-20 z-40 w-[min(320px,80vw)] overflow-hidden rounded-3xl border border-white/10 bg-white/90 p-6 text-slate-800 shadow-xl dark:border-slate-700/60 dark:bg-slate-900/90 dark:text-white`}
+            className={`absolute ${isRTL ? "left-4" : "right-4"} top-20 z-40 w-[min(320px,80vw)] overflow-hidden rounded-3xl border border-border-light bg-surface-light/95 p-6 text-gray-800 shadow-xl shadow-slate-900/10 dark:border-border-dark dark:bg-surface-dark/95 dark:text-slate-100`}
             dir={direction}
           >
             <div className="flex flex-col gap-4 [dir='rtl']:items-end">
@@ -41,14 +41,14 @@ export const NavDrawer = ({ navItems, policyLabel }: NavDrawerProps) => {
                   key={item.id}
                   href={`/${item.href}`}
                   onClick={createClickHandler(item.href, () => setOpen(false))}
-                  className="text-lg font-semibold text-slate-700 transition hover:text-cyan-500 dark:text-slate-200"
+                  className="text-lg font-semibold text-gray-700 transition hover:text-accent dark:text-slate-200"
                 >
                   {item.label}
                 </a>
               ))}
               <RouterLink
                 to="/policy"
-                className="text-lg font-semibold text-cyan-500"
+                className="text-lg font-semibold text-accent"
                 onClick={() => setOpen(false)}
               >
                 {policyLabel}

--- a/src/components/layout/ThemeToggle.tsx
+++ b/src/components/layout/ThemeToggle.tsx
@@ -8,7 +8,7 @@ export const ThemeToggle = () => {
     <button
       type="button"
       onClick={toggleTheme}
-      className="relative flex h-10 w-10 items-center justify-center rounded-full border border-slate-200/60 bg-white/80 shadow-sm backdrop-blur dark:border-slate-700 dark:bg-slate-800"
+      className="relative flex h-10 w-10 items-center justify-center rounded-full border border-border-light bg-surface-light/80 text-muted shadow-sm backdrop-blur hover:text-accent dark:border-border-dark dark:bg-surface-dark/80 dark:text-text-dark"
       aria-label={theme === "light" ? "Activate dark mode" : "Activate light mode"}
     >
       <motion.span

--- a/src/components/sections/About.tsx
+++ b/src/components/sections/About.tsx
@@ -11,10 +11,14 @@ export const About = () => {
   const cta = translate("about.cta");
 
   return (
-    <SectionContainer id="about" className="relative" background="about">
-      <div className="pointer-events-none absolute inset-0 -z-10 gradient-ring opacity-70 dark:opacity-40" />
+    <SectionContainer
+      id="about"
+      className="relative rounded-[3rem] bg-[#f8fafc] shadow-[0_50px_120px_-70px_rgba(15,23,42,0.45)] dark:bg-[#111c30]"
+      background="about"
+    >
+      <div className="pointer-events-none absolute inset-0 -z-10 gradient-ring opacity-60 dark:opacity-30" />
       <motion.div
-        className="grid gap-10 rounded-3xl bg-white/70 p-10 shadow-xl shadow-slate-900/10 backdrop-blur-lg dark:bg-slate-900/70 md:grid-cols-[minmax(0,2fr)_minmax(0,1.1fr)]"
+        className="grid gap-10 rounded-3xl border border-border-light/80 bg-surface-light/95 p-10 shadow-2xl shadow-slate-900/10 backdrop-blur-lg dark:border-border-dark/70 dark:bg-surface-dark/95 md:grid-cols-[minmax(0,2fr)_minmax(0,1.1fr)]"
         initial={{ opacity: 0, x: isRTL ? 40 : -40 }}
         whileInView={{ opacity: 1, x: 0 }}
         viewport={{ once: true, amount: 0.4 }}
@@ -24,36 +28,36 @@ export const About = () => {
         <div className={`space-y-6 text-start [dir='rtl']:text-end ${isRTL ? "md:order-2" : "md:order-1"}`}>
           <div>
             <h2 className="section-heading">{translate("about.title")}</h2>
-            <p className="mt-3 text-lg font-semibold text-cyan-600 dark:text-cyan-300">{lead}</p>
+            <p className="mt-3 text-lg font-semibold text-accent dark:text-accent">{lead}</p>
           </div>
           {paragraphs.map((paragraph) => (
-            <p key={paragraph} className="text-lg leading-relaxed text-slate-700 dark:text-slate-200">
+            <p key={paragraph} className="text-lg leading-relaxed text-gray-700 dark:text-slate-200">
               {paragraph}
             </p>
           ))}
-          <div className="rounded-2xl border border-cyan-500/30 bg-cyan-500/10 p-6 text-base text-cyan-700 shadow-sm dark:border-cyan-400/40 dark:bg-cyan-500/10 dark:text-cyan-200 [dir='rtl']:text-end">
+          <div className="rounded-2xl border border-accent/40 bg-accent/10 p-6 text-base text-accent shadow-sm dark:border-accent/40 dark:bg-accent/15 dark:text-accent [dir='rtl']:text-end">
             <p className="font-semibold">{cta}</p>
           </div>
         </div>
         <div
-          className={`flex flex-col gap-8 rounded-2xl border border-white/40 bg-white/70 p-6 shadow-inner dark:border-slate-700/60 dark:bg-slate-900/60 ${isRTL ? "md:order-1" : "md:order-2"}`}
+          className={`flex flex-col gap-8 rounded-2xl border border-border-light bg-surface-light p-6 shadow-inner dark:border-border-dark dark:bg-surface-dark ${isRTL ? "md:order-1" : "md:order-2"}`}
         >
           <div>
-            <h3 className="text-xl font-semibold text-slate-900 dark:text-white">{translate("about.credentialsTitle")}</h3>
-            <ul className="mt-4 space-y-3 text-sm leading-relaxed text-slate-600 dark:text-slate-300 [dir='rtl']:text-end">
+            <h3 className="text-xl font-semibold text-gray-900 dark:text-slate-100">{translate("about.credentialsTitle")}</h3>
+            <ul className="mt-4 space-y-3 text-sm leading-relaxed text-gray-700 dark:text-slate-300 [dir='rtl']:text-end">
               {credentials.map((item) => (
-                <li key={item} className="rounded-xl bg-cyan-500/5 px-4 py-2">
+                <li key={item} className="rounded-xl bg-accent/10 px-4 py-2 text-gray-800 dark:text-slate-200">
                   {item}
                 </li>
               ))}
             </ul>
           </div>
           <div>
-            <h3 className="text-xl font-semibold text-slate-900 dark:text-white">{translate("about.connectTitle")}</h3>
-            <ul className="mt-4 space-y-2 text-sm font-semibold text-cyan-600 dark:text-cyan-300 [dir='rtl']:text-end">
+            <h3 className="text-xl font-semibold text-gray-900 dark:text-slate-100">{translate("about.connectTitle")}</h3>
+            <ul className="mt-4 space-y-2 text-sm font-semibold text-accent dark:text-accent [dir='rtl']:text-end">
               {links.map((link) => (
                 <li key={link.href}>
-                  <a href={link.href} className="transition hover:text-indigo-500" target="_blank" rel="noreferrer">
+                  <a href={link.href} className="transition hover:text-accentSecondary" target="_blank" rel="noreferrer">
                     {link.label}: {link.value}
                   </a>
                 </li>

--- a/src/components/sections/Contact.tsx
+++ b/src/components/sections/Contact.tsx
@@ -34,17 +34,21 @@ export const Contact = () => {
   };
 
   return (
-    <SectionContainer id="contact" background="contact">
+    <SectionContainer
+      id="contact"
+      background="contact"
+      className="rounded-[3rem] bg-[#f1f5f9] shadow-[0_40px_100px_-60px_rgba(15,23,42,0.35)] dark:bg-[#0f172a]"
+    >
       <div
-        className="mx-auto grid max-w-6xl gap-12 rounded-3xl bg-white/70 p-10 shadow-xl backdrop-blur dark:bg-slate-900/70 md:grid-cols-2"
+        className="mx-auto grid max-w-6xl gap-12 rounded-3xl border border-border-light bg-surface-light/95 p-10 shadow-xl shadow-slate-900/10 backdrop-blur dark:border-border-dark dark:bg-surface-dark/95 md:grid-cols-2"
         dir={direction}
       >
         <div className={`text-start [dir='rtl']:text-end ${isRTL ? "md:order-2" : "md:order-1"}`}>
           <h2 className="section-heading">{title}</h2>
           <p className="section-subheading">{subtitle}</p>
-          <p className="mt-4 text-base leading-relaxed text-slate-600 dark:text-slate-300">{invitation}</p>
+          <p className="mt-4 text-base leading-relaxed text-gray-700 dark:text-slate-300">{invitation}</p>
           <motion.ul
-            className="mt-8 grid gap-3 text-sm text-slate-600 dark:text-slate-300 text-start [dir='rtl']:text-end"
+            className="mt-8 grid gap-3 text-sm text-gray-700 dark:text-slate-300 text-start [dir='rtl']:text-end"
             initial={{ opacity: 0, y: 16 }}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
@@ -54,12 +58,12 @@ export const Contact = () => {
               <li key={channel.href}>
                 <a
                   href={channel.href}
-                  className="group inline-flex items-center justify-between gap-3 rounded-2xl border border-transparent bg-white/50 px-4 py-3 font-semibold text-cyan-600 transition hover:border-cyan-300 hover:bg-cyan-500/10 hover:text-indigo-500 dark:bg-slate-800/60 dark:text-cyan-300 [dir='rtl']:flex-row-reverse"
+                  className="group inline-flex items-center justify-between gap-3 rounded-2xl border border-border-light bg-surface-light px-4 py-3 font-semibold text-accent transition hover:border-accent hover:bg-accent/10 hover:text-accentSecondary dark:border-border-dark dark:bg-surface-dark dark:text-accent [dir='rtl']:flex-row-reverse"
                   target="_blank"
                   rel="noreferrer"
                 >
                   <span>{channel.label}</span>
-                  <span className="text-sm font-medium text-slate-500 transition group-hover:text-indigo-400 dark:text-slate-300">
+                  <span className="text-sm font-medium text-muted transition group-hover:text-accentSecondary dark:text-slate-300">
                     {channel.value}
                   </span>
                 </a>
@@ -83,14 +87,14 @@ export const Contact = () => {
             onChange={(event) => setDraft({ ...draft, email: event.target.value })}
             required
           />
-          <label className="flex flex-col gap-2 text-sm font-medium text-slate-600 dark:text-slate-300">
+          <label className="flex flex-col gap-2 text-sm font-medium text-gray-600 dark:text-slate-300">
             <span>{formLabels.message}</span>
             <textarea
               name="message"
               value={draft.message}
               onChange={(event) => setDraft({ ...draft, message: event.target.value })}
               rows={5}
-              className="rounded-2xl border border-slate-200/60 bg-white/90 px-4 py-3 text-base text-slate-900 shadow-sm focus:border-cyan-400 focus:outline-none focus:ring-2 focus:ring-cyan-200 dark:border-slate-700/70 dark:bg-slate-800/80 dark:text-white dark:focus:border-cyan-400"
+              className="rounded-2xl border border-border-light bg-surface-light px-4 py-3 text-base text-gray-800 shadow-sm placeholder:text-slate-400 focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/30 dark:border-border-dark dark:bg-surface-dark dark:text-slate-100 dark:placeholder:text-slate-400 dark:focus:border-accent"
               required
             />
           </label>
@@ -100,7 +104,7 @@ export const Contact = () => {
           <motion.div
             initial={false}
             animate={submitted ? { opacity: 1, y: 0 } : { opacity: 0, y: 20 }}
-            className="rounded-2xl border border-cyan-500/40 bg-cyan-500/10 px-4 py-3 text-sm font-semibold text-cyan-700 dark:text-cyan-200 text-start [dir='rtl']:text-end"
+            className="rounded-2xl border border-accent/40 bg-accent/10 px-4 py-3 text-sm font-semibold text-accent dark:text-accent text-start [dir='rtl']:text-end"
           >
             {submitted ? translate("contact.success") : ""}
           </motion.div>

--- a/src/components/sections/Courses.tsx
+++ b/src/components/sections/Courses.tsx
@@ -35,39 +35,44 @@ export const Courses = () => {
   }, []);
 
   return (
-    <SectionContainer id="courses" className="text-center" background="courses">
+    <SectionContainer
+      id="courses"
+      className="text-center rounded-[3rem] bg-[#f1f5f9] shadow-[0_40px_100px_-60px_rgba(15,23,42,0.35)] dark:bg-[#0f172a]"
+      background="courses"
+    >
       <div className="mx-auto max-w-3xl" dir={direction}>
         <h2 className="section-heading text-balance">{title}</h2>
         <p className="section-subheading mx-auto">{subtitle}</p>
-        <p className="mt-4 text-sm font-semibold uppercase tracking-[0.2em] text-cyan-600 dark:text-cyan-300">{nativeNote}</p>
+        <p className="mt-4 text-sm font-semibold uppercase tracking-[0.2em] text-accent dark:text-accent">{nativeNote}</p>
       </div>
-        <div className="mt-12 grid gap-6 md:grid-cols-2" dir={direction}>
-          {groups.map((group) => (
-            <Card
-              key={group.region}
-              hoverGlow
-              className="flex h-full flex-col gap-6 p-8 text-start [dir='rtl']:text-end"
+      <div className="mt-12 grid gap-6 md:grid-cols-2" dir={direction}>
+        {groups.map((group) => (
+          <Card key={group.region} hoverGlow className="flex h-full flex-col gap-6 p-8 text-start [dir='rtl']:text-end">
+            <motion.div
+              initial={{ opacity: 0, y: 16 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.5, ease: easeOut }}
+              viewport={{ once: true }}
             >
-            <motion.div initial={{ opacity: 0, y: 16 }} whileInView={{ opacity: 1, y: 0 }} transition={{ duration: 0.5, ease: easeOut }} viewport={{ once: true }}>
-              <h3 className="text-2xl font-semibold text-slate-900 dark:text-white">{group.region}</h3>
-              <p className="mt-1 text-sm font-semibold uppercase tracking-wide text-cyan-500 dark:text-cyan-300">
+              <h3 className="text-2xl font-semibold text-gray-900 dark:text-slate-100">{group.region}</h3>
+              <p className="mt-1 text-sm font-semibold uppercase tracking-wide text-accent dark:text-accent">
                 {group.audience}
               </p>
-              <p className="mt-3 text-base leading-relaxed text-slate-600 dark:text-slate-300">{group.note}</p>
+              <p className="mt-3 text-base leading-relaxed text-gray-700 dark:text-slate-300">{group.note}</p>
             </motion.div>
             <ul className="flex flex-col gap-4">
               {group.courses.map((course) => (
-                  <li
-                    key={`${group.region}-${course.language}-${course.duration}`}
-                    className="rounded-2xl border border-white/40 bg-white/60 p-4 shadow-inner transition duration-300 hover:border-cyan-400/60 hover:shadow-lg dark:border-slate-700/60 dark:bg-slate-900/60"
-                  >
-                    <div className="flex flex-col gap-2">
-                      <div className="flex flex-wrap items-center justify-between gap-2 [dir='rtl']:flex-row-reverse">
-                        <span className="text-lg font-semibold text-slate-900 dark:text-white">{course.language}</span>
-                        <span className="text-sm font-semibold text-cyan-600 dark:text-cyan-300">{course.duration}</span>
-                      </div>
-                    <p className="text-base font-semibold text-slate-900 dark:text-white">{course.price}</p>
-                    <p className="text-sm leading-relaxed text-slate-600 dark:text-slate-300">{course.description}</p>
+                <li
+                  key={`${group.region}-${course.language}-${course.duration}`}
+                  className="rounded-2xl border border-border-light bg-surface-light/95 p-4 shadow-sm transition duration-300 hover:border-accent/60 hover:shadow-lg dark:border-border-dark dark:bg-surface-dark/80"
+                >
+                  <div className="flex flex-col gap-2">
+                    <div className="flex flex-wrap items-center justify-between gap-2 [dir='rtl']:flex-row-reverse">
+                      <span className="text-lg font-semibold text-gray-900 dark:text-slate-100">{course.language}</span>
+                      <span className="text-sm font-semibold text-accent dark:text-accent">{course.duration}</span>
+                    </div>
+                    <p className="text-base font-semibold text-gray-900 dark:text-slate-100">{course.price}</p>
+                    <p className="text-sm leading-relaxed text-gray-700 dark:text-slate-300">{course.description}</p>
                   </div>
                 </li>
               ))}
@@ -79,7 +84,7 @@ export const Courses = () => {
         ))}
       </div>
       <motion.p
-        className="mt-10 text-sm font-medium uppercase tracking-[0.3em] text-slate-500 dark:text-slate-400"
+        className="mt-10 text-sm font-medium uppercase tracking-[0.3em] text-muted dark:text-slate-400"
         initial={{ opacity: 0, y: 12 }}
         whileInView={{ opacity: 1, y: 0 }}
         viewport={{ once: true }}

--- a/src/components/sections/Features.tsx
+++ b/src/components/sections/Features.tsx
@@ -44,11 +44,11 @@ const AnimatedStat = ({
 
   return (
     <div className="text-start [dir='rtl']:text-end" dir={direction}>
-      <p className="text-4xl font-semibold text-slate-900 dark:text-white">
+      <p className="text-4xl font-semibold text-gray-900 dark:text-slate-100">
         {display}
         {suffix}
       </p>
-      <p className="mt-2 text-sm uppercase tracking-widest text-slate-500 dark:text-slate-400">{label}</p>
+      <p className="mt-2 text-sm uppercase tracking-widest text-muted dark:text-slate-400">{label}</p>
     </div>
   );
 };
@@ -73,7 +73,7 @@ export const Features = () => {
       >
         <h2 className="section-heading text-balance">{title}</h2>
         <p className="section-subheading mx-auto text-balance">{subtitle}</p>
-        <p className="mt-6 text-base leading-relaxed text-slate-600 dark:text-slate-300">{description}</p>
+        <p className="mt-6 text-base leading-relaxed text-gray-700 dark:text-slate-300">{description}</p>
       </motion.div>
       <div className="mt-12 grid gap-6 md:grid-cols-3" dir={direction}>
         {pillars.map((pillar) => (
@@ -82,10 +82,10 @@ export const Features = () => {
             hoverGlow
             className="flex h-full flex-col gap-4 p-8 text-start [dir='rtl']:text-end"
           >
-            <motion.h3 className="text-2xl font-semibold text-slate-900 dark:text-white" whileHover={{ scale: 1.02 }}>
+            <motion.h3 className="text-2xl font-semibold text-gray-900 dark:text-slate-100" whileHover={{ scale: 1.02 }}>
               {pillar.title}
             </motion.h3>
-            <p className="text-base leading-relaxed text-slate-600 dark:text-slate-300">{pillar.description}</p>
+            <p className="text-base leading-relaxed text-gray-700 dark:text-slate-300">{pillar.description}</p>
           </Card>
         ))}
       </div>

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -24,22 +24,22 @@ export const Hero = () => {
       className="relative flex min-h-screen items-center overflow-hidden px-6 pt-32"
       dir={direction}
     >
-      <div className="absolute inset-0 -z-10 bg-gradient-to-br from-cyan-400/20 via-transparent to-indigo-500/10" />
-      <div className="pointer-events-none absolute -left-40 top-40 h-96 w-96 rounded-full bg-cyan-400/30 blur-3xl [dir='rtl']:-right-40 [dir='rtl']:left-auto" />
-      <div className="pointer-events-none absolute -right-32 bottom-10 h-80 w-80 rounded-full bg-indigo-500/25 blur-3xl [dir='rtl']:-left-32 [dir='rtl']:right-auto" />
+      <div className="absolute inset-0 -z-10 bg-gradient-to-br from-white via-[#f1f5f9] to-[#e2e8f0] dark:from-[#0f172a] dark:via-[#1e293b] dark:to-[#1e293b]" />
+      <div className="pointer-events-none absolute -left-40 top-40 h-96 w-96 rounded-full bg-accent/25 blur-3xl [dir='rtl']:-right-40 [dir='rtl']:left-auto" />
+      <div className="pointer-events-none absolute -right-32 bottom-10 h-80 w-80 rounded-full bg-accentSecondary/20 blur-3xl [dir='rtl']:-left-32 [dir='rtl']:right-auto" />
       <motion.div
         initial="hidden"
         animate="visible"
         variants={heroVariants}
         className="mx-auto flex w-full max-w-5xl flex-col items-start gap-8 text-start [dir='rtl']:items-end [dir='rtl']:text-end"
       >
-        <motion.span style={{ y }} className="rounded-full bg-white/40 px-4 py-2 text-sm font-semibold uppercase tracking-widest text-cyan-600 shadow-sm backdrop-blur dark:bg-slate-800/60">
+        <motion.span style={{ y }} className="rounded-full bg-surface-light/80 px-4 py-2 text-sm font-semibold uppercase tracking-widest text-accent shadow-sm backdrop-blur dark:bg-surface-dark/70 dark:text-accent">
           {translate("hero.eyebrow")}
         </motion.span>
-        <motion.h1 style={{ y }} className="text-balance text-4xl font-semibold leading-tight text-slate-900 sm:text-6xl dark:text-white">
+        <motion.h1 style={{ y }} className="text-balance text-4xl font-semibold leading-tight text-gray-900 sm:text-6xl dark:text-slate-100">
           {translate("hero.title")}
         </motion.h1>
-        <motion.p style={{ y }} className="max-w-2xl text-lg leading-relaxed text-slate-600 dark:text-slate-300">
+        <motion.p style={{ y }} className="max-w-2xl text-lg leading-relaxed text-gray-700 dark:text-slate-300">
           {translate("hero.subtitle")}
         </motion.p>
         <div className="flex flex-wrap items-center gap-4 [dir='rtl']:flex-row-reverse [dir='rtl']:justify-end">
@@ -50,7 +50,7 @@ export const Hero = () => {
         </div>
         <motion.div
           style={{ y }}
-          className="mt-12 flex items-center gap-3 text-sm font-medium text-slate-500 [dir='rtl']:flex-row-reverse"
+          className="mt-12 flex items-center gap-3 text-sm font-medium text-muted [dir='rtl']:flex-row-reverse"
         >
           <span className="animate-bounce text-2xl">↓</span>
           <span>{translate("hero.scrollHint")}</span>

--- a/src/components/sections/Pricing.tsx
+++ b/src/components/sections/Pricing.tsx
@@ -21,7 +21,11 @@ export const Pricing = () => {
   const badge = translate("pricing.badge");
 
   return (
-    <SectionContainer id="pricing" className="text-center" background="pricing">
+    <SectionContainer
+      id="pricing"
+      className="text-center rounded-[3rem] bg-[#f8fafc] shadow-[0_40px_100px_-60px_rgba(15,23,42,0.35)] dark:bg-[#111c30]"
+      background="pricing"
+    >
       <div className="mx-auto max-w-3xl" dir={direction}>
         <h2 className="section-heading text-balance">{translate("pricing.title")}</h2>
         <p className="section-subheading mx-auto">{translate("pricing.subtitle")}</p>
@@ -39,27 +43,27 @@ export const Pricing = () => {
               hoverGlow
               className={`h-full p-8 text-start [dir='rtl']:text-end ${
                 plan.highlighted
-                  ? "border-cyan-400/70 bg-gradient-to-br from-cyan-500/20 via-sky-500/10 to-indigo-500/20"
+                  ? "border-accent bg-gradient-to-br from-accent/25 via-accentSecondary/15 to-accentSecondary/25"
                   : ""
               }`}
             >
               <div className="flex items-center justify-between [dir='rtl']:flex-row-reverse">
-                <h3 className="text-2xl font-semibold text-slate-900 dark:text-white">{plan.name}</h3>
+                <h3 className="text-2xl font-semibold text-gray-900 dark:text-slate-100">{plan.name}</h3>
                 {plan.highlighted ? (
-                  <span className="rounded-full bg-cyan-500/20 px-3 py-1 text-xs font-semibold uppercase text-cyan-700 dark:text-cyan-200">
+                  <span className="rounded-full bg-accent/20 px-3 py-1 text-xs font-semibold uppercase text-accent dark:text-accent">
                     {badge}
                   </span>
                 ) : null}
               </div>
-              <p className="mt-6 text-sm uppercase tracking-wider text-slate-500 dark:text-slate-300">{plan.description}</p>
-              <p className="mt-6 text-4xl font-semibold text-slate-900 dark:text-white">
+              <p className="mt-6 text-sm uppercase tracking-wider text-muted dark:text-slate-300">{plan.description}</p>
+              <p className="mt-6 text-4xl font-semibold text-gray-900 dark:text-slate-100">
                 {plan.price}
-                <span className="ms-2 text-base font-medium text-slate-500 dark:text-slate-300">{plan.period}</span>
+                <span className="ms-2 text-base font-medium text-muted dark:text-slate-300">{plan.period}</span>
               </p>
-              <ul className="mt-6 space-y-3 text-sm text-slate-600 dark:text-slate-300">
+              <ul className="mt-6 space-y-3 text-sm text-gray-700 dark:text-slate-300">
                 {plan.features.map((feature) => (
                   <li key={feature} className="flex items-center gap-2 [dir='rtl']:flex-row-reverse">
-                    <span className="text-cyan-500">•</span>
+                    <span className="text-accent">•</span>
                     <span>{feature}</span>
                   </li>
                 ))}

--- a/src/components/sections/Rules.tsx
+++ b/src/components/sections/Rules.tsx
@@ -22,25 +22,29 @@ export const Rules = () => {
   const [agreed, setAgreed] = useLocalStorage<boolean>("saos-policy-agreed", false);
 
   return (
-    <SectionContainer id="rules" background="rules">
+    <SectionContainer
+      id="rules"
+      background="rules"
+      className="rounded-[3rem] bg-[#f8fafc] shadow-[0_40px_100px_-60px_rgba(15,23,42,0.35)] dark:bg-[#111c30]"
+    >
       <div
-        className="mx-auto max-w-4xl rounded-3xl border border-white/20 bg-white/70 p-10 shadow-xl backdrop-blur dark:border-slate-700/60 dark:bg-slate-900/70"
+        className="mx-auto max-w-4xl rounded-3xl border border-border-light bg-surface-light/95 p-10 shadow-xl shadow-slate-900/10 backdrop-blur dark:border-border-dark dark:bg-surface-dark/95"
         dir={direction}
       >
         <h2 className="section-heading text-center">{translate("rules.title")}</h2>
         <p className="section-subheading mx-auto text-center">{translate("rules.description")}</p>
-        <div className="mt-10 rounded-2xl bg-white/70 p-6 shadow-inner dark:bg-slate-900/70">
+        <div className="mt-10 rounded-2xl border border-border-light/70 bg-surface-light p-6 shadow-inner dark:border-border-dark/70 dark:bg-surface-dark">
           <Accordion
             items={sections.map((section, index) => ({ id: `${index}`, title: section.title, content: section.content }))}
           />
         </div>
-        <div className="mt-8 flex flex-col gap-4 text-sm text-slate-600 dark:text-slate-300">
+        <div className="mt-8 flex flex-col gap-4 text-sm text-gray-700 dark:text-slate-300">
           <label className="flex items-center gap-3 [dir='rtl']:flex-row-reverse">
             <input
               type="checkbox"
               checked={agreed}
               onChange={() => setAgreed(!agreed)}
-              className="h-5 w-5 rounded border border-slate-300 text-cyan-500 focus:ring-cyan-200 dark:border-slate-600"
+              className="h-5 w-5 rounded border border-border-light text-accent focus:ring-accent/30 dark:border-border-dark"
             />
             <span>{acknowledgement}</span>
           </label>
@@ -58,8 +62,8 @@ export const Rules = () => {
         <div className="space-y-6">
           {sections.map((section) => (
             <div key={section.title}>
-              <h3 className="text-lg font-semibold text-slate-900 dark:text-white">{section.title}</h3>
-              <div className="mt-2 space-y-3 text-sm leading-relaxed text-slate-600 dark:text-slate-300">
+              <h3 className="text-lg font-semibold text-gray-900 dark:text-slate-100">{section.title}</h3>
+              <div className="mt-2 space-y-3 text-sm leading-relaxed text-gray-700 dark:text-slate-300">
                 {section.content.map((paragraph) => (
                   <p key={paragraph}>{paragraph}</p>
                 ))}

--- a/src/components/sections/Testimonials.tsx
+++ b/src/components/sections/Testimonials.tsx
@@ -37,12 +37,12 @@ export const Testimonials = () => {
               hoverGlow
               className="min-w-[280px] max-w-sm flex-1 p-8 text-start [dir='rtl']:text-end"
             >
-              <div className="flex items-center justify-between text-sm font-semibold text-cyan-500 [dir='rtl']:flex-row-reverse">
+              <div className="flex items-center justify-between text-sm font-semibold text-accent [dir='rtl']:flex-row-reverse">
                 <span>{item.rating}</span>
                 <span>{item.country}</span>
               </div>
-              <p className="mt-6 text-start text-base leading-relaxed text-slate-600 dark:text-slate-300 [dir='rtl']:text-end">“{item.quote}”</p>
-              <p className="mt-8 text-start text-lg font-semibold text-slate-900 dark:text-white [dir='rtl']:text-end">{item.name}</p>
+              <p className="mt-6 text-start text-base leading-relaxed text-gray-700 dark:text-slate-300 [dir='rtl']:text-end">“{item.quote}”</p>
+              <p className="mt-8 text-start text-lg font-semibold text-gray-900 dark:text-slate-100 [dir='rtl']:text-end">{item.name}</p>
             </Card>
           ))}
         </motion.div>

--- a/src/components/ui/Accordion.tsx
+++ b/src/components/ui/Accordion.tsx
@@ -15,7 +15,7 @@ export const Accordion = ({ items }: AccordionProps) => {
   const [openId, setOpenId] = useState<string | null>(items[0]?.id ?? null);
 
   return (
-    <div className="divide-y divide-slate-200/40 dark:divide-slate-700/60">
+    <div className="divide-y divide-border-light dark:divide-border-dark/80">
       {items.map((item) => {
         const isOpen = openId === item.id;
         return (
@@ -23,11 +23,11 @@ export const Accordion = ({ items }: AccordionProps) => {
             <button
               type="button"
               onClick={() => setOpenId(isOpen ? null : item.id)}
-              className="flex w-full items-center justify-between gap-4 py-4 text-start text-lg font-medium text-slate-800 transition hover:text-cyan-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-200 dark:text-white [dir='rtl']:flex-row-reverse [dir='rtl']:text-end"
+              className="flex w-full items-center justify-between gap-4 py-4 text-start text-lg font-medium text-gray-800 transition hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/30 dark:text-slate-100 [dir='rtl']:flex-row-reverse [dir='rtl']:text-end"
               aria-expanded={isOpen}
             >
               <span>{item.title}</span>
-              <span className="text-2xl text-cyan-500">{isOpen ? "−" : "+"}</span>
+              <span className="text-2xl text-accent">{isOpen ? "−" : "+"}</span>
             </button>
             <AnimatePresence initial={false}>
               {isOpen ? (
@@ -39,7 +39,7 @@ export const Accordion = ({ items }: AccordionProps) => {
                   transition={{ duration: 0.3, ease: "easeOut" }}
                   className="overflow-hidden"
                 >
-                  <div className="pb-4 text-base leading-relaxed text-slate-600 dark:text-slate-300 text-start [dir='rtl']:text-end">
+                  <div className="pb-4 text-base leading-relaxed text-gray-700 dark:text-slate-300 text-start [dir='rtl']:text-end">
                     {item.content.map((paragraph) => (
                       <p key={paragraph} className="mb-4 last:mb-0">
                         {paragraph}

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -11,11 +11,12 @@ type ButtonProps = HTMLMotionProps<"button"> & {
 };
 
 const variantClasses: Record<ButtonVariant, string> = {
-  primary: "bg-cyan-500 text-slate-900 shadow-glow hover:bg-cyan-400 focus-visible:ring-2 focus-visible:ring-cyan-200",
+  primary:
+    "bg-accent text-white shadow-glow hover:bg-sky-500 focus-visible:ring-2 focus-visible:ring-accent/30 dark:hover:bg-sky-400",
   secondary:
-    "border border-cyan-500/60 text-cyan-500 hover:bg-cyan-500/10 focus-visible:ring-2 focus-visible:ring-cyan-200",
+    "border border-accent text-accent hover:bg-accent/10 focus-visible:ring-2 focus-visible:ring-accent/30 dark:hover:bg-accent/20",
   ghost:
-    "text-slate-700 hover:bg-slate-900/5 focus-visible:ring-2 focus-visible:ring-cyan-200 dark:text-slate-200 dark:hover:bg-white/5",
+    "text-gray-700 hover:bg-slate-900/5 focus-visible:ring-2 focus-visible:ring-accent/20 dark:text-slate-200 dark:hover:bg-white/10",
 };
 
 const sizeClasses = {

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -14,18 +14,16 @@ export const Card = forwardRef<HTMLDivElement, CardProps>(({ children, className
   return (
     <motion.div
       ref={ref}
-      whileHover={hoverGlow ? { y: -6, boxShadow: "0 30px 60px -30px rgba(56, 189, 248, 0.6)" } : undefined}
-      transition={{ type: "spring", stiffness: 240, damping: 20 }}
+      whileHover={hoverGlow ? { scale: 1.02, boxShadow: "0 18px 40px -24px rgba(15, 23, 42, 0.25)" } : undefined}
+      transition={{ duration: 0.4, ease: "easeOut" }}
       className={cn(
-        "glass-panel glass-border relative overflow-hidden",
-        "bg-white/70 dark:bg-slate-800/70",
-        "border border-white/40 dark:border-white/10",
-        "shadow-lg shadow-slate-900/5",
+        "glass-panel relative overflow-hidden",
+        "border border-border-light/70 bg-surface-light/90 shadow-md shadow-slate-900/5 dark:border-border-dark/70 dark:bg-surface-dark/90",
         "transition-all duration-300",
         className
       )}
     >
-      <div className="pointer-events-none absolute inset-x-8 -top-28 h-40 rounded-full bg-cyan-400/20 blur-3xl" />
+      <div className="pointer-events-none absolute inset-x-8 -top-28 h-40 rounded-full bg-accent/20 blur-3xl" />
       <div className="relative z-10 h-full">{children}</div>
     </motion.div>
   );

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -11,15 +11,15 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
   ({ label, className, id, ...props }, ref) => {
     const inputId = id ?? props.name ?? label;
     return (
-      <label className="flex w-full flex-col gap-2 text-sm font-medium text-slate-600 dark:text-slate-300" htmlFor={inputId}>
+      <label className="flex w-full flex-col gap-2 text-sm font-medium text-gray-600 dark:text-slate-300" htmlFor={inputId}>
         <span>{label}</span>
         <input
           ref={ref}
           id={inputId}
           className={cn(
-            "rounded-2xl border border-slate-200/60 bg-white/90 px-4 py-3 text-base text-slate-900 shadow-sm",
-            "focus:border-cyan-400 focus:outline-none focus:ring-2 focus:ring-cyan-200",
-            "dark:border-slate-700/70 dark:bg-slate-800/80 dark:text-white dark:focus:border-cyan-400",
+            "rounded-2xl border border-border-light bg-surface-light px-4 py-3 text-base text-gray-800 shadow-sm placeholder:text-slate-400",
+            "focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/30",
+            "dark:border-border-dark dark:bg-surface-dark dark:text-slate-100 dark:placeholder:text-slate-400 dark:focus:border-accent",
             className
           )}
           {...props}

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -41,27 +41,27 @@ export const Modal = ({ open, onClose, title, children }: ModalProps) => {
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
         >
-          <div className="absolute inset-0 bg-slate-900/60 backdrop-blur-md" onClick={onClose} />
+          <div className="absolute inset-0 bg-slate-900/50 backdrop-blur-sm" onClick={onClose} />
           <motion.div
             role="document"
             dir={direction}
-            className="glass-panel w-full max-w-2xl overflow-hidden bg-white/90 p-8 text-slate-900 dark:bg-slate-900/80 dark:text-white"
+            className="glass-panel w-full max-w-2xl overflow-hidden border border-border-light bg-surface-light/95 p-8 text-gray-800 shadow-xl shadow-slate-900/10 dark:border-border-dark dark:bg-surface-dark/95 dark:text-slate-100"
             initial={{ opacity: 0, scale: 0.95, y: 20 }}
             animate={{ opacity: 1, scale: 1, y: 0 }}
             exit={{ opacity: 0, scale: 0.95, y: 20 }}
             transition={{ duration: 0.25, ease: "easeOut" }}
           >
             <header className="mb-6 flex items-start justify-between gap-6 [dir='rtl']:flex-row-reverse">
-              <h2 className="text-2xl font-semibold text-slate-900 dark:text-white">{title}</h2>
+              <h2 className="text-2xl font-semibold text-gray-900 dark:text-slate-100">{title}</h2>
               <button
                 onClick={onClose}
-                className="rounded-full border border-transparent bg-slate-900/5 p-2 text-slate-500 transition hover:bg-slate-900/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-200 dark:bg-white/10 dark:text-slate-200"
+                className="rounded-full border border-transparent bg-slate-900/5 p-2 text-muted transition hover:bg-slate-900/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/30 dark:bg-white/10 dark:text-slate-200"
                 aria-label="Close"
               >
                 ×
               </button>
             </header>
-            <div className="space-y-4 text-base leading-relaxed text-slate-600 dark:text-slate-300 text-start [dir='rtl']:text-end">
+            <div className="space-y-4 text-base leading-relaxed text-gray-700 dark:text-slate-300 text-start [dir='rtl']:text-end">
               {children}
             </div>
           </motion.div>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -17,7 +17,7 @@ const LoadingPlaceholder = () => (
     animate={{ opacity: 0.6 }}
     transition={{ repeat: Infinity, duration: 1.2, repeatType: "reverse" }}
   >
-    <div className="h-24 rounded-3xl bg-white/40 backdrop-blur dark:bg-slate-800/40" />
+    <div className="h-24 rounded-3xl bg-surface-light/80 backdrop-blur dark:bg-surface-dark/80" />
   </motion.div>
 );
 

--- a/src/pages/Policy.tsx
+++ b/src/pages/Policy.tsx
@@ -12,18 +12,21 @@ const Policy = () => {
   const sections = translate<PolicySection[]>("policy.sections");
 
   return (
-    <div className="mx-auto flex min-h-screen w-full max-w-4xl flex-col gap-10 px-6 pb-32 pt-32" dir={direction}>
-      <div className="rounded-3xl border border-white/30 bg-white/70 p-10 shadow-xl backdrop-blur dark:border-slate-700/60 dark:bg-slate-900/70">
-        <h1 className="text-4xl font-semibold text-slate-900 dark:text-white">{translate("policy.title")}</h1>
-        <p className="mt-4 text-lg leading-relaxed text-slate-600 dark:text-slate-300">{translate("policy.intro")}</p>
+    <div
+      className="mx-auto flex min-h-screen w-full max-w-4xl flex-col gap-10 rounded-[3rem] bg-[#f8fafc] px-6 pb-32 pt-32 shadow-[0_50px_120px_-70px_rgba(15,23,42,0.45)] dark:bg-[#111c30]"
+      dir={direction}
+    >
+      <div className="rounded-3xl border border-border-light bg-surface-light/95 p-10 shadow-xl shadow-slate-900/10 backdrop-blur dark:border-border-dark dark:bg-surface-dark/95">
+        <h1 className="text-4xl font-semibold text-gray-900 dark:text-slate-100">{translate("policy.title")}</h1>
+        <p className="mt-4 text-lg leading-relaxed text-gray-700 dark:text-slate-300">{translate("policy.intro")}</p>
         <div className="mt-10 space-y-8">
           {sections.map((section) => (
             <div
               key={section.title}
-              className="rounded-2xl border border-white/20 bg-white/60 p-6 shadow-inner dark:border-slate-700/50 dark:bg-slate-900/60"
+              className="rounded-2xl border border-border-light bg-surface-light p-6 shadow-inner dark:border-border-dark dark:bg-surface-dark"
             >
-              <h2 className="text-2xl font-semibold text-slate-900 dark:text-white">{section.title}</h2>
-              <div className="mt-3 space-y-4 text-base leading-relaxed text-slate-600 dark:text-slate-300 text-start [dir='rtl']:text-end">
+              <h2 className="text-2xl font-semibold text-gray-900 dark:text-slate-100">{section.title}</h2>
+              <div className="mt-3 space-y-4 text-base leading-relaxed text-gray-700 dark:text-slate-300 text-start [dir='rtl']:text-end">
                 {section.content.map((paragraph) => (
                   <p key={paragraph}>{paragraph}</p>
                 ))}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -5,15 +5,26 @@
 @tailwind utilities;
 
 @layer base {
+  * {
+    transition: color 0.25s ease, background-color 0.25s ease, border-color 0.25s ease;
+  }
+
   :root {
     color-scheme: light;
-    --surface-light: 255 255 255;
-    --surface-dark: 15 23 42;
-    --panel-light: 248 250 252;
-    --panel-dark: 30 41 59;
-    --text-light: 15 23 42;
-    --text-dark: 226 232 240;
+    --px-bg: theme("colors.background.light");
+    --px-surface: theme("colors.surface.light");
+    --px-text: theme("colors.text.light");
+    --px-text-muted: theme("colors.text.mutedLight");
     scroll-behavior: smooth;
+  }
+
+  body[data-theme="dark"],
+  .dark {
+    color-scheme: dark;
+    --px-bg: theme("colors.background.dark");
+    --px-surface: theme("colors.surface.dark");
+    --px-text: theme("colors.text.dark");
+    --px-text-muted: theme("colors.text.mutedDark");
   }
 
   html {
@@ -21,11 +32,11 @@
   }
 
   body {
-    @apply bg-white text-slate-900 antialiased transition-colors duration-300 ease-out;
+    @apply antialiased transition-colors duration-300 ease-out;
     font-family: "Source Sans 3", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-    background: rgb(var(--surface-light));
-    color: rgb(var(--text-light));
-    transition: all 0.3s ease-in-out;
+    background-color: var(--px-bg);
+    color: var(--px-text);
+    transition: all 0.3s ease;
   }
 
   html[dir="rtl"] body {
@@ -56,12 +67,6 @@
     text-align: left;
   }
 
-  body[data-theme="dark"] {
-    @apply text-slate-100;
-    background: rgb(var(--surface-dark));
-    color: rgb(var(--text-dark));
-  }
-
   h1,
   h2,
   h3,
@@ -69,31 +74,31 @@
   h5,
   h6 {
     font-family: inherit;
-    @apply text-slate-900 dark:text-slate-100;
+    @apply text-gray-900 dark:text-slate-100;
   }
 
   ::selection {
-    @apply bg-cyan-300/60 text-slate-900;
+    @apply bg-accent/40 text-gray-900;
   }
 }
 
 @layer components {
   .glass-panel {
-    @apply rounded-3xl border border-white/10 bg-white/60 backdrop-blur-xl shadow-lg shadow-slate-900/5 transition-colors duration-300 ease-out dark:border-slate-700/60 dark:bg-slate-800/60 dark:shadow-slate-900/40;
+    @apply rounded-3xl border border-border-light/60 bg-surface-light/80 backdrop-blur-xl shadow-lg shadow-slate-900/5 transition-colors duration-300 ease-out dark:border-border-dark/60 dark:bg-surface-dark/80 dark:shadow-slate-900/40;
   }
 
   .gradient-ring {
     background:
-      radial-gradient(circle at top, rgba(34, 211, 238, 0.35), transparent 55%),
-      radial-gradient(circle at bottom, rgba(129, 140, 248, 0.35), transparent 60%);
+      radial-gradient(circle at top, rgba(34, 211, 238, 0.25), transparent 55%),
+      radial-gradient(circle at bottom, rgba(129, 140, 248, 0.25), transparent 60%);
   }
 
   .section-heading {
-    @apply text-3xl font-semibold tracking-tight text-slate-900 sm:text-4xl dark:text-white;
+    @apply text-3xl font-semibold tracking-tight text-gray-900 sm:text-4xl dark:text-slate-100;
   }
 
   .section-subheading {
-    @apply mt-3 max-w-2xl text-lg leading-relaxed text-slate-600 dark:text-slate-300;
+    @apply mt-3 max-w-2xl text-lg leading-relaxed text-gray-600 dark:text-slate-300;
   }
 }
 
@@ -103,14 +108,10 @@
   }
 
   .bg-surface {
-    background: rgb(var(--surface-light));
+    background: var(--px-surface);
   }
 
-  body[data-theme="dark"] .bg-surface {
-    background: rgb(var(--surface-dark));
-  }
-
-  body[data-theme="dark"] .glass-border {
-    box-shadow: 0 0 0 1px rgba(56, 189, 248, 0.2);
+  .text-muted {
+    color: var(--px-text-muted);
   }
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -8,6 +8,29 @@ export default {
   theme: {
     extend: {
       colors: {
+        background: {
+          light: "#f9fafb",
+          dark: "#0f172a",
+        },
+        surface: {
+          light: "#ffffff",
+          dark: "#1e293b",
+        },
+        text: {
+          light: "#1e293b",
+          dark: "#e2e8f0",
+          mutedLight: "#475569",
+          mutedDark: "#94a3b8",
+        },
+        border: {
+          light: "#e2e8f0",
+          dark: "#334155",
+        },
+        accent: "#38bdf8",
+        accentSecondary: "#818cf8",
+        success: "#16a34a",
+        warning: "#f59e0b",
+        error: "#ef4444",
         midnight: {
           900: "#0f172a",
           800: "#1e293b"


### PR DESCRIPTION
## Summary
- extend the Tailwind palette with warm background, surface, text, and accent tokens for light mode harmony
- introduce global theme variables and smooth transitions while updating layout/navigation to the new premium light aesthetic
- refresh hero, about, courses, pricing, contact, policy, and supporting UI components with elevated surfaces, accent highlights, and balanced typography

## Testing
- npm run build *(fails: npm is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e64b62e0708329bcd55bef542f878e